### PR TITLE
[docs] README: add link to the aruba tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This is a simple app to get started with `aruba`.
 
-It comes with an executable, [`aruba-test-cli`](https://github.com/cli-testing/aruba-getting-started/blob/master/exe/aruba-test-cli), which is the applictation under test in the _Your First Tests with "aruba"_ tutorial steps in the [aruba documentation](https://app.cucumber.pro/projects/aruba#your-first-tests-with-aruba).
+It comes with an executable, [`aruba-test-cli`](https://github.com/cli-testing/aruba-getting-started/blob/master/exe/aruba-test-cli), which is the application under test in the _Your First Tests with "aruba"_ tutorial steps in the [aruba documentation](https://app.cucumber.pro/projects/aruba#your-first-tests-with-aruba).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Simple Cli App
 
 This is a simple app to get started with `aruba`.
+
+It comes with an executable, [`aruba-test-cli`](https://github.com/cli-testing/aruba-getting-started/blob/master/exe/aruba-test-cli), which is the applictation under test in the _Your First Tests with "aruba"_ tutorial steps in the [aruba documentation](https://app.cucumber.pro/projects/aruba#your-first-tests-with-aruba).


### PR DESCRIPTION
This PR adds a short description and a link to the executable that is the app under test in the tutorial. We also link to the tutorial.



See also https://github.com/cucumber/aruba/issues/453