### PR TITLE
aruba-test-cli: use Kernel#abort for a simpler test app

### DIFF
--- a/exe/aruba-test-cli
+++ b/exe/aruba-test-cli
@@ -3,11 +3,9 @@
 file = ARGV[0]
 
 if file.nil? || file.empty?
-  $stderr.puts "aruba-test-cli [file]: Filename is missing"
-  exit 1
+  abort "aruba-test-cli [file]: Filename is missing"
 elsif !File.exist? file
-  $stderr.puts "aruba-test-cli [file]: File does not exist"
-  exit 1
+  abort "aruba-test-cli [file]: File does not exist"
 end
 
 puts File.read(file).chomp


### PR DESCRIPTION
This PR simplifies the app under test by using [Kernel#abort](https://ruby-doc.org/core-2.4.1/Kernel.html#method-i-abort).

  - abort is stderr.puts + exit 1